### PR TITLE
index aligned assembly BAM

### DIFF
--- a/workflows/sample/tasks/hifiasm.wdl
+++ b/workflows/sample/tasks/hifiasm.wdl
@@ -230,7 +230,8 @@ task align_hifiasm {
     echo "$(conda info)"
 
     (minimap2 -t ~{minimap2_threads} ~{minimap2_args} -R "~{readgroup}" ~{target.datafile} ~{sep=" " query} \
-            | samtools sort -@ ~{samtools_threads} -T $PWD -m ~{samtools_mem} > ~{asm_bam_name}) > ~{log_name} 2>&1
+            | samtools sort -@ ~{samtools_threads} -T $PWD -m ~{samtools_mem} > ~{asm_bam_name} \
+            && samtools index -@ ~{samtools_threads} ~{asm_bam_name}) > ~{log_name} 2>&1
   >>>
   output {
     File asm_bam = "~{asm_bam_name}"


### PR DESCRIPTION
added `samtools index` command to index the aligned assembly, since `asm_bai` was included in the outputs without a command to generate