### PR TITLE
reworked cohort pbsv call task

### DIFF
--- a/workflows/cohort/cohort.wdl
+++ b/workflows/cohort/cohort.wdl
@@ -111,7 +111,6 @@ workflow cohort {
 
   output {
     IndexedData pbsv_vcf    = pbsv.pbsv_vcf
-    Array[IndexedData] pbsv_individual_vcf    = pbsv.pbsv_individual_vcf
     IndexedData filt_vcf    = slivar.filt_vcf
     IndexedData comphet_vcf = slivar.filt_vcf
     File filt_tsv           = slivar.filt_tsv


### PR DESCRIPTION
This branch reworks the pbsv subworkflow for cohort level calling SVs.

Changes made: 
1) removing per chromosome splitting of identifying SVs with pbsv_call
2) Increases hardware requirements for pbsv_call task to reflect the increased demand of the task
3) eliminates unnecessary indexing and concatenation tasks for creating final SV VCF file

Overall workflow runtime is unaffected due to speedy nature of this task, elimination of unnecessary indexing and concatenation tasks, and the subworkflow is much more streamlined. Ready for merge & data test.